### PR TITLE
Add Cypress data-cy attributes to dataviews

### DIFF
--- a/AppBuilder/platform/views/ABViewDataview.js
+++ b/AppBuilder/platform/views/ABViewDataview.js
@@ -412,6 +412,18 @@ module.exports = class ABViewDataview extends ABViewDataviewCore {
             }
          }
 
+         //Add data-cy attributes for cypress tests
+         Layout.$view.setAttribute('data-cy', `dataview-container-${this.id}`)
+
+         Layout.getChildViews().forEach((child, i) => {
+            const id = rows[i + this._startPos]['id'];
+            const view = child.$view;
+            view.querySelector('.webix_accordionitem_body')
+               .setAttribute('data-cy', `dataview-item-${id}`);
+            view.querySelector('.webix_accordionitem_button')
+               .setAttribute('data-cy', `dataview-item-button-${id}`);
+         });
+
          com.logic.ready();
       };
 


### PR DESCRIPTION
I added data-cy attributes to the dataview items using the record's id. This will be consistent for any test data we preload, but will not be consistent for records added during the tests. I also added a data-cy attribute to the layout container. We could use other cypress commands like [`children()`](https://docs.cypress.io/api/commands/children#Syntax) and [`eq()`](https://docs.cypress.io/api/commands/eq#Syntax) to get the correct item.

Alternatively I can change to just use the index of the item in the dataview but I'm not sure if the index will be the same each time.