### PR TITLE
Vertical tab options, collapse/expand buttons have cyData

### DIFF
--- a/AppBuilder/platform/views/ABViewTab.js
+++ b/AppBuilder/platform/views/ABViewTab.js
@@ -749,6 +749,44 @@ module.exports = class ABViewTab extends ABViewTabCore {
                         // _onShow(id);
                      }
                   },
+                  onAfterRender: () => {
+                    // set ids of controller buttons
+                    let collapseNode = $$(ids.sidebar).$view.querySelector('[webix_tm_id="' + ids.collapseMenu + '"]')
+                    if (collapseNode){
+                      collapseNode.setAttribute(
+                        "data-cy",
+                        "tab-" +
+                          "collapseMenu" +
+                          "-" +
+                          ids.collapseMenu)
+                      }
+                    let expandNode = $$(ids.sidebar).$view.querySelector('[webix_tm_id="' + ids.expandMenu + '"]')
+                    if (expandNode){
+                      expandNode.setAttribute(
+                        "data-cy",
+                        "tab-" +
+                          "expandMenu" +
+                          "-" +
+                          ids.expandMenu)
+                      }
+                    this.views((view) => {
+                      var node = $$(
+                        ids.sidebar
+                        ).$view.querySelector(
+                          '[webix_tm_id="' + view.id + '_menu"]'
+                          );
+                          if (!node) return;
+                          node.setAttribute(
+                            "data-cy",
+                            "tab-" +
+                            view.label.replace(" ", "") +
+                            "-" +
+                            view.id +
+                            "-" +
+                            this.id
+                            );
+                    });
+                  },
                },
             };
 


### PR DESCRIPTION
Set id after render
POSSIBLE ISSUE:
Collapse/Expand options have their cy data set multiple times? I was unable to optimize this.