### PR TITLE
Fix error when detail text in dataview doesn't have a parent detail

### DIFF
--- a/AppBuilder/platform/views/ABViewDetailCheckbox.js
+++ b/AppBuilder/platform/views/ABViewDetailCheckbox.js
@@ -86,7 +86,7 @@ module.exports = class ABViewDetailCheckbox extends ABViewDetailCheckboxCore {
       var idBase = "ABViewDetailCheckbox_" + (idPrefix || "") + this.id;
       var ids = {
          component: App.unique(idBase + "_component"),
-         detail: this.parentDetailComponent().id,
+         detail: this.parentDetailComponent()?.id || this.parent.id,
       };
 
       component.ui.id = ids.component;

--- a/AppBuilder/platform/views/ABViewDetailCustom.js
+++ b/AppBuilder/platform/views/ABViewDetailCustom.js
@@ -92,7 +92,7 @@ module.exports = class ABViewDetailCustom extends ABViewDetailCustomCore {
       var idBase = "ABViewDetailCustom_" + (idPrefix || "") + this.id;
       var ids = {
          component: App.unique(idBase + "_component"),
-         detail: this.parentDetailComponent().id,
+         detail: this.parentDetailComponent()?.id || this.parent.id,
       };
 
       var templateLabel = "";

--- a/AppBuilder/platform/views/ABViewDetailImage.js
+++ b/AppBuilder/platform/views/ABViewDetailImage.js
@@ -113,7 +113,7 @@ module.exports = class ABViewDetailImage extends ABViewDetailImageCore {
       var idBase = "ABViewDetailImage_" + (idPrefix || "") + this.id;
       var ids = {
          component: App.unique(idBase + "_component"),
-         detail: this.parentDetailComponent().id,
+         detail: this.parentDetailComponent()?.id || this.parent.id,
       };
 
       var defaultImageUrl = field ? field.settings.defaultImageUrl : "";

--- a/AppBuilder/platform/views/ABViewDetailSelectivity.js
+++ b/AppBuilder/platform/views/ABViewDetailSelectivity.js
@@ -102,7 +102,7 @@ module.exports = class ABViewDetailSelectivity extends ABViewDetailSelectivityCo
       var idBase = "ABViewDetailSelectivity_" + (idPrefix || "") + this.id;
       var ids = {
          component: App.unique(idBase + "_component"),
-         detail: this.parentDetailComponent().id,
+         detail: this.parentDetailComponent()?.id || this.parent.id,
       };
       var className = "ab-detail-selectivity";
 

--- a/AppBuilder/platform/views/ABViewDetailText.js
+++ b/AppBuilder/platform/views/ABViewDetailText.js
@@ -102,7 +102,7 @@ module.exports = class ABViewDetailText extends ABViewDetailTextCore {
       var idBase = "ABViewDetailText_" + (idPrefix || "") + this.id;
       var ids = {
          component: App.unique(idBase + "_component"),
-         detail: this.parentDetailComponent().id,
+         detail: this.parentDetailComponent()?.id || this.parent.id,
       };
 
       component.ui.id = ids.component;


### PR DESCRIPTION
Because detail components in a dataview do not have a parent detail view.